### PR TITLE
Amending documentation URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ $ make build
 Using the provider
 ----------------------
 
-If you're building the provider, follow the instructions to [install it as a plugin.](https://www.terraform.io/docs/plugins/basics.html#installing-a-plugin) After placing it into your plugins directory,  run `terraform init` to initialize it. Documentation about the provider specific configuration options can be found on the [provider's website](https://www.terraform.io/docs/providers/rancher2/index.html).
+If you're building the provider, follow the instructions to [install it as a provider.](https://www.terraform.io/docs/language/providers/index.html#provider-installation) After placing it into your plugins directory,  run `terraform init` to initialize it. Documentation about the provider specific configuration options can be found on the [provider's website](https://www.terraform.io/docs/providers/rancher2/index.html).
 
 Developing the Provider
 ---------------------------


### PR DESCRIPTION
The old documentation URL didn't work. I believe this is the new equivalent.